### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/homolog-deploy.yml
+++ b/.github/workflows/homolog-deploy.yml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Push to GitHub Packages
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Push to GitHub Packages
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore